### PR TITLE
fixes for MSVC windows compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(ENCODEC_LIB encodec)
 
 add_subdirectory(ggml)
 
-add_library(${ENCODEC_LIB} encodec.cpp encodec.h)
+add_library(${ENCODEC_LIB} STATIC encodec.cpp encodec.h)
 
 if (ENCODEC_BUILD_EXAMPLES)
     add_subdirectory(examples)


### PR DESCRIPTION
In GGML, the GGML_OP_COUNT parameter needed to be increased, as it was exceeding its limit. Mac and Linux compilers like GCC and clang must fix this at compile time, but MSVC throws an error. Just incrementing the number to what we need fixes this. 

Finally, it was also compiling as a .dll, not as a .lib, with Windows CMake, so adding the static keyword fixes this. Everything should still compile under Linux, we'll see if the CI you added proves this. 